### PR TITLE
fix(core-utils): startLogic was called in incorrect context.

### DIFF
--- a/packages/api/core/src/util/plugin-interface.ts
+++ b/packages/api/core/src/util/plugin-interface.ts
@@ -153,7 +153,7 @@ export default class PluginInterface implements IForgePluginInterface {
     for (const plugin of this.plugins) {
       if (typeof plugin.startLogic === 'function' && plugin.startLogic !== PluginBase.prototype.startLogic) {
         claimed.push(plugin.name);
-        newStartFn = plugin.startLogic;
+        newStartFn = plugin.startLogic.bind(plugin);
       }
     }
     if (claimed.length > 1) {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Fixed startLogic being called in incorrect context.
